### PR TITLE
Feature mean code size

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -18,6 +18,10 @@ void Character::printCharacter() const {
     //std::cout << std::endl;
 }
 
+const std::vector<bool> &Character::getCode() const {
+    return code;
+}
+
 void Character::setCode(const std::shared_ptr<std::vector<bool>> &codeToCopy, unsigned int codeSize) {
     /*
      * Set the huffman code of the character

--- a/src/character.h
+++ b/src/character.h
@@ -30,6 +30,8 @@ public:
     void printCharacter() const;
 
     void setCode(const std::shared_ptr<std::vector<bool>> &codeToCopy, unsigned int codeSize);
+
+    [[nodiscard]] const std::vector<bool> &getCode() const;
 };
 
 #endif //DECODAGE_HUFFMAN_CHARACTER_H

--- a/src/huffman_decoding.cpp
+++ b/src/huffman_decoding.cpp
@@ -28,5 +28,6 @@ void mainDecode(const std::string& filePath) {
 
     tree->decodeFile("../texts/textesimple_comp.bin", "../texts/textesimple_res.txt");
 
-    std::cout << tree->getCompressionRatio();
+    std::cout << "Compression ratio: " << tree->getCompressionRatio() << std::endl;
+    std::cout << "Mean code size: " << tree->getMeanCodeSize() << std::endl;
 }

--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -225,11 +225,23 @@ void Tree::decodeFile(const std::string &filePath, const std::string &outPutFile
     this->nbByteBinFile = byteCount;
     this->nbByteDecodedFile = this->alphabet->getNumCharacters();
 
+    std::cout << std::endl;
+
     binaryFile.close();
     outPutFile.close();
 }
 
-float Tree::getCompressionRatio() const {
-    std::cout << this->nbByteDecodedFile << std::endl;
-    return 1 - ((float) this->nbByteBinFile / (float) this->nbByteDecodedFile);
+long double Tree::getCompressionRatio() const {
+    return 1 - ((long double) this->nbByteBinFile / this->nbByteDecodedFile);
+}
+
+float Tree::getMeanCodeSize() {
+    unsigned int sumCodeSizes = 0;
+
+    for(const std::shared_ptr<Character>& c: *this->alphabet->getListCharacter()) {
+        sumCodeSizes += c->getCode().size();
+    }
+
+    return (float) sumCodeSizes / (float) this->alphabet->getListCharacter()->size();
+
 }

--- a/src/tree.h
+++ b/src/tree.h
@@ -42,7 +42,9 @@ public:
 
     void decodeFile(const std::string& filePath, const std::string& outPutFilePath);
 
-    float getCompressionRatio() const;
+    [[nodiscard]] long double getCompressionRatio() const;
+
+    [[nodiscard]] float getMeanCodeSize();
 };
 
 #endif //DECODAGE_HUFFMAN_TREE_H


### PR DESCRIPTION
Implementing #9 
Added a function in tree.h/c to compute the mean code size of the huffman codes.
Also added a getter of the huffman code vector.